### PR TITLE
Replaced mkdir() with makedirs() to avoid errors when creating the 

### DIFF
--- a/chromedriver_autoinstaller/utils.py
+++ b/chromedriver_autoinstaller/utils.py
@@ -185,7 +185,7 @@ def download_chromedriver(cwd=False):
             not check_version(chromedriver_filepath, chromedriver_version):
         logging.debug(f'Downloading chromedriver ({chromedriver_version})...')
         if not os.path.isdir(chromedriver_dir):
-            os.mkdir(chromedriver_dir)
+            os.makedirs(chromedriver_dir)
         url = get_chromedriver_url(version=chromedriver_version)
         try:
             response = urllib.request.urlopen(url)


### PR DESCRIPTION
I encountered errors saying that "System cannot find the path specified" when trying to run my application which uses **python-chromedriver-autoinstaller**  as a exe in windows. 
I think it's because mkdir is used and it's trying to create the folder"cwd/chrome_autoinstaller/84" to download the chromedriver into. Since the folder chromer_unistaller does not exist, this fails.
Using makedirs() on the other hand creates the folder "chrome_autoinstaller" if it does not exist before creating the folder "84". 
