### PR TITLE
Enable chrome beta on Linux

### DIFF
--- a/chromedriver_autoinstaller/utils.py
+++ b/chromedriver_autoinstaller/utils.py
@@ -99,9 +99,20 @@ def get_chrome_version():
     """
     platform, _ = get_platform_architecture()
     if platform == 'linux':
-        with subprocess.Popen(['chromium-browser', '--version'], stdout=subprocess.PIPE) as proc:
-            version = proc.stdout.read().decode('utf-8').replace('Chromium', '').strip()
-            version = version.replace('Google Chrome', '').strip()
+        try:
+            with subprocess.Popen(['chromium', '--version'], stdout=subprocess.PIPE) as proc:
+                version = proc.stdout.read().decode('utf-8').replace('Chromium', '').strip()
+        except FileNotFoundError:
+            try:
+                with subprocess.Popen(['google-chrome', '--version'], stdout=subprocess.PIPE) as proc:
+                    version = proc.stdout.read().decode('utf-8').replace('Google Chrome', '').strip()
+            except FileNotFoundError:
+                try:
+                    with subprocess.Popen(['google-chrome-beta', '--version'], stdout=subprocess.PIPE) as proc:
+                        version = proc.stdout.read().decode('utf-8').replace('Google Chrome', '').strip()
+                except FileNotFoundError:
+                    with subprocess.Popen(['google-chrome-dev', '--version'], stdout=subprocess.PIPE) as proc:
+                        version = proc.stdout.read().decode('utf-8').replace('Google Chrome', '').strip()
     elif platform == 'mac':
         process = subprocess.Popen(['/Applications/Google Chrome.app/Contents/MacOS/Google Chrome', '--version'], stdout=subprocess.PIPE)
         version = process.communicate()[0].decode('UTF-8').replace('Google Chrome', '').strip()

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ elif sys.argv[-1] == 'clean':
 
 setup(
     name="chromedriver-autoinstaller",
-    version="0.2.1",
+    version="0.2.2",
     author="Yeongbin Jo",
     author_email="iam.yeongbin.jo@gmail.com",
     description="Automatically install chromedriver that supports the currently installed version of chrome.",


### PR DESCRIPTION
Through a a cascade of Throw Except blocks, it is possible to use the chromedriver-autoinstaller with Chromium or Google Chrome (Stable/Beta/Dev) installed. Code could be refactored in different functions with decorators.