### PR TITLE
handle google-chrome in linux

### DIFF
--- a/chromedriver_autoinstaller/utils.py
+++ b/chromedriver_autoinstaller/utils.py
@@ -99,9 +99,14 @@ def get_chrome_version():
     """
     platform, _ = get_platform_architecture()
     if platform == 'linux':
-        with subprocess.Popen(['chromium-browser', '--version'], stdout=subprocess.PIPE) as proc:
-            version = proc.stdout.read().decode('utf-8').replace('Chromium', '').strip()
-            version = version.replace('Google Chrome', '').strip()
+        try:
+            with subprocess.Popen(['chromium-browser', '--version'], stdout=subprocess.PIPE) as proc:
+                version = proc.stdout.read().decode('utf-8').replace('Chromium', '').strip()
+                version = version.replace('Google Chrome', '').strip()
+        except FileNotFoundError:
+            with subprocess.Popen(["google-chrome", "--version"], stdout=subprocess.PIPE) as proc:
+                version = proc.stdout.read().decode("utf-8")
+                version = version.split(" ")[2]
     elif platform == 'mac':
         process = subprocess.Popen(['/Applications/Google Chrome.app/Contents/MacOS/Google Chrome', '--version'], stdout=subprocess.PIPE)
         version = process.communicate()[0].decode('UTF-8').replace('Google Chrome', '').strip()


### PR DESCRIPTION
chrome installed directly by .deb files won't be reachable by chromium-browser but will be reachable google-chrome command, the proposed changes handles this case with minimal modification to code.

needless to say chromium-browser and google-chrome can have different versions and if both exist (and with different versions) it could potentially result in version problems. Maybe an indicator would be nice.