### PR TITLE
Option to specify path to download the chromedriver.exe to

### DIFF
--- a/chromedriver_autoinstaller/__init__.py
+++ b/chromedriver_autoinstaller/__init__.py
@@ -5,14 +5,14 @@ import logging
 from . import utils
 
 
-def install(cwd=False):
+def install(path:str=None):
     """
     Appends the directory of the chromedriver binary file to PATH.
 
     :param cwd: Flag indicating whether to download to current working directory
     :return: The file path of chromedriver
     """
-    chromedriver_filepath = utils.download_chromedriver(cwd)
+    chromedriver_filepath = utils.download_chromedriver(path)
     if not chromedriver_filepath:
         logging.debug('Can not download chromedriver.')
         return

--- a/chromedriver_autoinstaller/utils.py
+++ b/chromedriver_autoinstaller/utils.py
@@ -151,12 +151,12 @@ def print_chromedriver_path():
     print(get_chromedriver_path())
 
 
-def download_chromedriver(cwd=False):
+def download_chromedriver(path:str=None):
     """
     Downloads, unzips and installs chromedriver.
     If a chromedriver binary is found in PATH it will be copied, otherwise downloaded.
 
-    :param cwd: Flag indicating whether to download to current working directory
+    :param str path: Path of the directory where to save the downloaded chromedriver to.
     :return: The file path of chromedriver
     """
     chrome_version = get_chrome_version()
@@ -165,13 +165,15 @@ def download_chromedriver(cwd=False):
         return
     chromedriver_version = get_matched_chromedriver_version(chrome_version)
     if not chromedriver_version:
-        logging.debug('Can not find chromedriver for currently installed chrome version.')
+        logging.warning('Can not find chromedriver for currently installed chrome version.')
         return
     major_version = get_major_version(chromedriver_version)
 
-    if cwd:
+    if path:
+        if not os.path.isdir(path):
+            raise ValueError(f'Invalid path: {path}')
         chromedriver_dir = os.path.join(
-            os.path.abspath(os.getcwd()),
+            os.path.abspath(path),
             major_version
         )
     else:
@@ -183,7 +185,7 @@ def download_chromedriver(cwd=False):
     chromedriver_filepath = os.path.join(chromedriver_dir, chromedriver_filename)
     if not os.path.isfile(chromedriver_filepath) or \
             not check_version(chromedriver_filepath, chromedriver_version):
-        logging.debug(f'Downloading chromedriver ({chromedriver_version})...')
+        logging.info(f'Downloading chromedriver ({chromedriver_version})...')
         if not os.path.isdir(chromedriver_dir):
             os.makedirs(chromedriver_dir)
         url = get_chromedriver_url(version=chromedriver_version)
@@ -197,7 +199,7 @@ def download_chromedriver(cwd=False):
         with zipfile.ZipFile(archive) as zip_file:
             zip_file.extract(chromedriver_filename, chromedriver_dir)
     else:
-        logging.debug('Chromedriver is already installed.')
+        logging.info('Chromedriver is already installed.')
     if not os.access(chromedriver_filepath, os.X_OK):
         os.chmod(chromedriver_filepath, 0o744)
     return chromedriver_filepath


### PR DESCRIPTION
Substituted the cwd argument in the `chromedriver_autoinstaller.install()` method to a `path `argument (str), which will specify the folder (directory) to install the chromedrivers to.