### PR TITLE
patch for get_chrome_version's list index out of range "reg query" error

### DIFF
--- a/chromedriver_autoinstaller/utils.py
+++ b/chromedriver_autoinstaller/utils.py
@@ -110,7 +110,15 @@ def get_chrome_version():
             ['reg', 'query', 'HKEY_CURRENT_USER\\Software\\Google\\Chrome\\BLBeacon', '/v', 'version'],
             stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, stdin=subprocess.DEVNULL
         )
-        version = process.communicate()[0].decode('UTF-8').strip().split()[-1]
+        output = process.communicate()
+        if not output:
+            version = out[0].decode('UTF-8').strip().split()[-1]
+        else:
+            process = subprocess.Popen(
+                ['powershell', '-command', '$(Get-ItemProperty -Path Registry::HKEY_CURRENT_USER\\Software\\Google\\chrome\\BLBeacon).version'],
+                stdout=subprocess.PIPE, stderr=subprocess.PIPE, stdin=subprocess.PIPE
+            )
+            version = process.communicate()[0].decode('UTF-8').strip()
     else:
         return
     return version

--- a/chromedriver_autoinstaller/utils.py
+++ b/chromedriver_autoinstaller/utils.py
@@ -112,7 +112,7 @@ def get_chrome_version():
         )
         output = process.communicate()
         if not output:
-            version = out[0].decode('UTF-8').strip().split()[-1]
+            version = output[0].decode('UTF-8').strip().split()[-1]
         else:
             process = subprocess.Popen(
                 ['powershell', '-command', '$(Get-ItemProperty -Path Registry::HKEY_CURRENT_USER\\Software\\Google\\chrome\\BLBeacon).version'],

--- a/chromedriver_autoinstaller/utils.py
+++ b/chromedriver_autoinstaller/utils.py
@@ -111,7 +111,7 @@ def get_chrome_version():
             stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, stdin=subprocess.DEVNULL
         )
         output = process.communicate()
-        if not output:
+        if output:
             version = output[0].decode('UTF-8').strip().split()[-1]
         else:
             process = subprocess.Popen(


### PR DESCRIPTION
Users on a restricted registry-access windows machines face the following error:

```
version = process.communicate()[0].decode('UTF-8').strip().split()[-1]
IndexError: list index out of range
``` 
due to `reg query` erring out with `ERROR: Registry editing has been disabled by your administrator.`.
Alternative Powershell's `Get-ItemProperty` works fine in cases I have tested.