### PR TITLE
more robust test of process output

### DIFF
--- a/chromedriver_autoinstaller/utils.py
+++ b/chromedriver_autoinstaller/utils.py
@@ -114,7 +114,7 @@ def get_chrome_version():
             stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, stdin=subprocess.DEVNULL
         )
         output = process.communicate()
-        if output:
+        if output and output[0] and len(output[0]) > 0:
             version = output[0].decode('UTF-8').strip().split()[-1]
         else:
             process = subprocess.Popen(


### PR DESCRIPTION
The `output` from `process.communicate()` needs to be checked more thoroughly than just making sure it isn't `None`. Otherwise, it produces an error `IndexError: list index out of range`:

```diff
chromedriver_autoinstaller.install(cwd=True)
(b'', None)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "C:\Users\mavad\AppData\Local\Programs\Python\Python310\lib\site-packages\chromedriver_autoinstaller\__init__.py", line 20, in install  
    chromedriver_filepath = utils.download_chromedriver(path)
  File "C:\Users\mavad\AppData\Local\Programs\Python\Python310\lib\site-packages\chromedriver_autoinstaller\utils.py", line 196, in download_chromedriver    chrome_version = get_chrome_version()
  File "C:\Users\mavad\AppData\Local\Programs\Python\Python310\lib\site-packages\chromedriver_autoinstaller\utils.py", line 119, in get_chrome_version    version = output[0].decode('UTF-8').strip().split()[-1]
IndexError: list index out of range
```