### PR TITLE
Made so it doesn't show a CMD window when this code runs on a compiled .exe file

### DIFF
--- a/chromedriver_autoinstaller/utils.py
+++ b/chromedriver_autoinstaller/utils.py
@@ -107,7 +107,7 @@ def get_chrome_version():
     platform, _ = get_platform_architecture()
     if platform == "linux":
         path = get_linux_executable_path()
-        with subprocess.Popen([path, "--version"], stdout=subprocess.PIPE) as proc:
+        with subprocess.Popen([path, "--version"], stdout=subprocess.PIPE, shell=True) as proc:
             version = (
                 proc.stdout.read()
                 .decode("utf-8")
@@ -122,6 +122,7 @@ def get_chrome_version():
                 "--version",
             ],
             stdout=subprocess.PIPE,
+            shell=True
         )
         version = (
             process.communicate()[0]
@@ -141,6 +142,7 @@ def get_chrome_version():
             stdout=subprocess.PIPE,
             stderr=subprocess.DEVNULL,
             stdin=subprocess.DEVNULL,
+            shell=True
         )
         output = process.communicate()
         if output and output[0] and len(output[0]) > 0:
@@ -155,6 +157,7 @@ def get_chrome_version():
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 stdin=subprocess.PIPE,
+                shell=True
             )
             version = process.communicate()[0].decode("UTF-8").strip()
     else:


### PR DESCRIPTION
When you create an .exe file which runs `chromedriver_autoinstaller.install()`, it briefly shows a CMD window that run any `subprocess.Popen` command that is on the `utils.py` file.

It doesn't show any windows after appending `shell=True` to every `subprocess.Popen` command on that file.

(In my case, the .exe file was created using nuitka with the ` --windows-disable-console` option)