### PR TITLE
Support ChromeDriver versions 115 and above

### DIFF
--- a/chromedriver_autoinstaller/utils.py
+++ b/chromedriver_autoinstaller/utils.py
@@ -87,12 +87,12 @@ def get_chromedriver_url(chromedriver_version, no_ssl=False):
     Generates the download URL for current platform , architecture and the given version.
     Supports Linux, MacOS and Windows.
 
-    :param chromedriver_version: chromedriver version string
-    :param no_ssl:               Whether to use the encryption protocol when downloading the chrome driver.
+    :param chromedriver_version: ChromeDriver version string
+    :param no_ssl:               Whether to use the encryption protocol when downloading the chrome driver
     :return:                     String. Download URL for chromedriver
     """
     platform, architecture = get_platform_architecture(chromedriver_version)
-    if chromedriver_version >= "115":  # old ChromeDriver versions use the old urls
+    if chromedriver_version >= "115":  # new CfT ChromeDriver versions have their URLs published
         versions_url = "googlechromelabs.github.io/chrome-for-testing/known-good-versions-with-downloads.json"
         versions_url = "http://" + versions_url if no_ssl else "https://" + versions_url
         download_version_list = json.load(urllib.request.urlopen(versions_url))
@@ -100,9 +100,9 @@ def get_chromedriver_url(chromedriver_version, no_ssl=False):
             if good_version["version"] == chromedriver_version:
                 download_urls = good_version["downloads"]["chromedriver"]
                 for url in download_urls:
-                    if url["platform"] == platform+architecture:
+                    if url["platform"] == platform + architecture:
                         return url['url']
-    else:
+    else:  # old ChromeDriver versions use the old urls
         base_url = "chromedriver.storage.googleapis.com/"
         base_url = "http://" + base_url if no_ssl else "https://" + base_url
         return base_url + chromedriver_version + "/chromedriver_" + platform + architecture + ".zip"

--- a/chromedriver_autoinstaller/utils.py
+++ b/chromedriver_autoinstaller/utils.py
@@ -212,12 +212,9 @@ def get_matched_chromedriver_version(chrome_version, no_ssl=False):
                            None.   if no matching version of chromedriver was discovered
     """
     # Newer versions of chrome use the CfT publishing system
-    if int(get_major_version(chrome_version)) >= 115:
+    if chrome_version >= "115":
         version_url = "googlechromelabs.github.io/chrome-for-testing/known-good-versions.json"
-        if no_ssl:
-            version_url = "http://" + version_url
-        else:
-            version_url = "https://" + version_url
+        version_url = "http://" + version_url if no_ssl else "https://" + version_url
         good_version_list = json.load(urllib.request.urlopen(version_url))
         for good_version in good_version_list["versions"]:
             if good_version["version"] == chrome_version:
@@ -225,10 +222,7 @@ def get_matched_chromedriver_version(chrome_version, no_ssl=False):
     # check old versions of chrome using the old system
     else:
         version_url = "chromedriver.storage.googleapis.com"
-        if no_ssl:
-            version_url = "http://" + version_url
-        else:
-            version_url = "https://" + version_url
+        version_url = "http://" + version_url if no_ssl else "https://" + version_url
         doc = urllib.request.urlopen(version_url).read()
         root = elemTree.fromstring(doc)
         for k in root.iter("{http://doc.s3.amazonaws.com/2006-03-01}Key"):

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ elif sys.argv[-1] == "clean":
 
 setup(
     name="chromedriver-autoinstaller",
-    version="0.4.1",
+    version="0.5.0",
     author="Yeongbin Jo",
     author_email="iam.yeongbin.jo@gmail.com",
     description="Automatically install chromedriver that supports the currently installed version of chrome.",


### PR DESCRIPTION
The Google team recently has introduced a Chrome stream called "Chrome for Test" (CfT).

This introduced several side effects for downloading ChromeDriver:

- The version lists & binaries are hosted at a new URL
- The version lists are published as JSON files
- The ZIP files nest their files inside directories
- The MacOS architecture naming convention has changed

This PR attempts to support these changes while maintaining backwards compatibility with older Chrome / ChromeDriver versions.

It has been tested on MacOS x64 architecture.  From examining the JSON version data, I have reason to believe other architectures will work as expected.