### PR TITLE
dwnld only most recent in major version for >=115

### DIFF
--- a/chromedriver_autoinstaller/utils.py
+++ b/chromedriver_autoinstaller/utils.py
@@ -56,8 +56,8 @@ def get_platform_architecture(chrome_version=None):
         # 115.0.5763.0/mac-arm64/chromedriver-mac-arm64.zip'
         # 115.0.5763.0/mac-x64/chromedriver-mac-x64.zip'
         if pf.processor() == "arm":
-            if chrome_version is not None and chrome_version >= "115.0.5763.0":
-                print("CHROME >= 115.0.5763.0, using mac-arm64 as architecture identifier")
+            if chrome_version is not None and chrome_version >= "115":
+                print("CHROME >= 115, using mac-arm64 as architecture identifier")
                 architecture = "-arm64"
             elif chrome_version is not None and chrome_version <= "106.0.5249.21":
                 print("CHROME <= 106.0.5249.21, using mac64_m1 as architecture identifier")
@@ -65,11 +65,11 @@ def get_platform_architecture(chrome_version=None):
             else:
                 architecture = "_arm64"
         elif pf.processor() == "i386":
-            if chrome_version is not None and chrome_version >= "115.0.5763.0":
-                print("CHROME >= 115.0.5763.0, using mac-x64 as architecture identifier")
+            if chrome_version is not None and chrome_version >= "115":
+                print("CHROME >= 115, using mac-x64 as architecture identifier")
                 architecture = "-x64"
             else:
-                architecture = "mac64"
+                architecture = "64"
         else:
             raise RuntimeError("Could not determine Mac processor architecture.")
     elif sys.platform.startswith("win"):
@@ -82,7 +82,7 @@ def get_platform_architecture(chrome_version=None):
     return platform, architecture
 
 
-def get_chromedriver_url(chromedriver_version, no_ssl=False):
+def get_chromedriver_url(chromedriver_version, download_options, no_ssl=False):
     """
     Generates the download URL for current platform , architecture and the given version.
     Supports Linux, MacOS and Windows.
@@ -92,16 +92,10 @@ def get_chromedriver_url(chromedriver_version, no_ssl=False):
     :return:                     String. Download URL for chromedriver
     """
     platform, architecture = get_platform_architecture(chromedriver_version)
-    if chromedriver_version >= "115":  # new CfT ChromeDriver versions have their URLs published
-        versions_url = "googlechromelabs.github.io/chrome-for-testing/known-good-versions-with-downloads.json"
-        versions_url = "http://" + versions_url if no_ssl else "https://" + versions_url
-        download_version_list = json.load(urllib.request.urlopen(versions_url))
-        for good_version in download_version_list["versions"]:
-            if good_version["version"] == chromedriver_version:
-                download_urls = good_version["downloads"]["chromedriver"]
-                for url in download_urls:
-                    if url["platform"] == platform + architecture:
-                        return url['url']
+    if chromedriver_version >= "115":  # new CfT ChromeDriver versions have their URLs published, so we already have a list of options
+        for option in download_options:
+            if option["platform"] == platform + architecture:
+                        return option['url']
     else:  # old ChromeDriver versions use the old urls
         base_url = "chromedriver.storage.googleapis.com/"
         base_url = "http://" + base_url if no_ssl else "https://" + base_url
@@ -219,12 +213,17 @@ def get_matched_chromedriver_version(chrome_version, no_ssl=False):
     """
     # Newer versions of chrome use the CfT publishing system
     if chrome_version >= "115":
-        version_url = "googlechromelabs.github.io/chrome-for-testing/known-good-versions.json"
-        version_url = "http://" + version_url if no_ssl else "https://" + version_url
-        good_version_list = json.load(urllib.request.urlopen(version_url))
-        for good_version in good_version_list["versions"]:
-            if good_version["version"] == chrome_version:
-                return chrome_version
+        browser_major_version = get_major_version(chrome_version)
+        version_url = "googlechromelabs.github.io/chrome-for-testing/latest-versions-per-milestone-with-downloads.json"
+        version_url = f"http://{version_url}" if no_ssl else f"https://{version_url}"
+        latest_version_per_milestone_list = json.load(urllib.request.urlopen(version_url))
+        # drill through object to make sure each key exists, to determin in driver download is available
+        if browser_major_version in latest_version_per_milestone_list['milestones']:
+            milestone = latest_version_per_milestone_list['milestones'][browser_major_version]
+            if 'downloads' in milestone:
+                if 'chromedriver' in milestone['downloads']:
+                    download_options = milestone['downloads']['chromedriver']
+                return browser_major_version, download_options
     # check old versions of chrome using the old system
     else:
         version_url = "chromedriver.storage.googleapis.com"
@@ -233,7 +232,8 @@ def get_matched_chromedriver_version(chrome_version, no_ssl=False):
         root = elemTree.fromstring(doc)
         for k in root.iter("{http://doc.s3.amazonaws.com/2006-03-01}Key"):
             if k.text.find(get_major_version(chrome_version) + ".") == 0:
-                return k.text.split("/")[0]
+                # Old system doesn't provide download options so return None
+                return k.text.split("/")[0], None
     return
 
 
@@ -264,7 +264,7 @@ def download_chromedriver(path: Optional[AnyStr] = None, no_ssl: bool = False):
     if not chrome_version:
         logging.debug("Chrome is not installed.")
         return
-    chromedriver_version = get_matched_chromedriver_version(chrome_version, no_ssl)
+    chromedriver_version, download_options = get_matched_chromedriver_version(chrome_version, no_ssl)
     if not chromedriver_version:
         logging.warning(
             "Can not find chromedriver for currently installed chrome version."
@@ -288,7 +288,7 @@ def download_chromedriver(path: Optional[AnyStr] = None, no_ssl: bool = False):
         logging.info(f"Downloading chromedriver ({chromedriver_version})...")
         if not os.path.isdir(chromedriver_dir):
             os.makedirs(chromedriver_dir)
-        url = get_chromedriver_url(chromedriver_version=chromedriver_version, no_ssl=no_ssl)
+        url = get_chromedriver_url(chromedriver_version=chromedriver_version, download_options=download_options, no_ssl=no_ssl)
         try:
             response = urllib.request.urlopen(url)
             if response.getcode() != 200:
@@ -313,3 +313,4 @@ def download_chromedriver(path: Optional[AnyStr] = None, no_ssl: bool = False):
 if __name__ == "__main__":
     print(get_chrome_version())
     print(download_chromedriver(no_ssl=False))
+  

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ elif sys.argv[-1] == "clean":
 
 setup(
     name="chromedriver-autoinstaller",
-    version="0.6.2",
+    version="0.6.3",
     author="Yeongbin Jo",
     author_email="iam.yeongbin.jo@gmail.com",
     description="Automatically install chromedriver that supports the currently installed version of chrome.",


### PR DESCRIPTION
I believe #54 is getting to be in a pretty good place. It seems like a good idea to try to make an exact match. However, I believe it only attempts to do this once per major version, and in some cases exact matches are not available.

This left me to question if exact version matches are really necessary for the purposes of this library. If they are not necessary, this PR offers a simplified way of selecting the most recent version per major version (or milestone as google calls it) by using the lighter [latest-versions-per-milestone-with-downloads.json](https://googlechromelabs.github.io/chrome-for-testing/latest-versions-per-milestone-with-downloads.json) end point. 

Since the new json endpoints provide download urls, I also made changes to collect url download options on the first api call, and eliminate the need for repeated api calls.

If wanted to be more nuanced about matching versions than what I'm proposing in the PR, we could consider downloading the driver for each build rather than each milestone. The latest-patch-versions-per-build api could help us with this.