### PR TITLE
Fix dir path not found error in win

### DIFF
--- a/chromedriver_autoinstaller/utils.py
+++ b/chromedriver_autoinstaller/utils.py
@@ -167,12 +167,16 @@ def get_chrome_version():
     elif platform == "win":
         # check both of Program Files and Program Files (x86).
         # if the version isn't found on both of them, version is an empty string.
-        dirs = [f.name for f in os.scandir("C:\\Program Files\\Google\\Chrome\\Application") if f.is_dir() and re.match("^[0-9.]+$", f.name)]
-        if dirs:
-            version = max(dirs)
-        else:
-            dirs = [f.name for f in os.scandir("C:\\Program Files (x86)\\Google\\Chrome\\Application") if f.is_dir() and re.match("^[0-9.]+$", f.name)]
+
+        if not os.path.exists(chrome_path):
+            chrome_path = "C:\\Program Files (x86)\\Google\\Chrome\\Application"
+
+        try:
+            dirs = [f.name for f in os.scandir(chrome_path) if f.is_dir() and re.match("^[0-9.]+$", f.name)]
             version = max(dirs) if dirs else ''
+        except FileNotFoundError:
+            version = ''
+            
     else:
         return
     return version


### PR DESCRIPTION
### Requirements
Version: chromedriver_autoinstaller==0.6.2
OS: windows

### Issue Description
if win path not exist will throw error

such as below logging:

```
  File "..\venv\lib\site-packages\chromedriver_autoinstaller\__init__.py", line 21, in install
    chromedriver_filepath = utils.download_chromedriver(path, no_ssl)
  File "..\venv\lib\site-packages\chromedriver_autoinstaller\utils.py", line 266, in download_chromedriver
    chrome_version = get_chrome_version()
  File "..\venv\lib\site-packages\chromedriver_autoinstaller\utils.py", line 170, in get_chrome_version
    dirs = [f.name for f in os.scandir("C:\\Program Files\\Google\\Chrome\\Application") if f.is_dir() and re.match("^[0-9.]+$", f.name)]
FileNotFoundError: [WinError 3] The system cannot find the path specified: 'C:\\Program Files\\Google\\Chrome\\Application'

```

### Solution
Add path exists checker