### PR TITLE
Fix #71 FileNotFoundError in Program Files

### DIFF
--- a/chromedriver_autoinstaller/utils.py
+++ b/chromedriver_autoinstaller/utils.py
@@ -163,12 +163,16 @@ def get_chrome_version():
     elif platform == "win":
         # check both of Program Files and Program Files (x86).
         # if the version isn't found on both of them, version is an empty string.
-        dirs = [f.name for f in os.scandir("C:\\Program Files\\Google\\Chrome\\Application") if f.is_dir() and re.match("^[0-9.]+$", f.name)]
-        if dirs:
+        PROGRAMFILES = "C:\\Program Files\\Google\\Chrome\\Application"
+        PROGRAMFILESX86 = "C:\\Program Files (x86)\\Google\\Chrome\\Application"
+        
+        path = PROGRAMFILES if os.path.exists(PROGRAMFILES) else PROGRAMFILESX86 if os.path.exists(PROGRAMFILESX86) else None
+
+        if path:
+            dirs = [f.name for f in os.scandir(path) if f.is_dir() and re.match("^[0-9.]+$", f.name)]
             version = max(dirs)
         else:
-            dirs = [f.name for f in os.scandir("C:\\Program Files (x86)\\Google\\Chrome\\Application") if f.is_dir() and re.match("^[0-9.]+$", f.name)]
-            version = max(dirs) if dirs else ''
+            version = ''
     else:
         return
     return version

--- a/chromedriver_autoinstaller/utils.py
+++ b/chromedriver_autoinstaller/utils.py
@@ -163,8 +163,8 @@ def get_chrome_version():
     elif platform == "win":
         # check both of Program Files and Program Files (x86).
         # if the version isn't found on both of them, version is an empty string.
-        PROGRAMFILES = "C:\\Program Files\\Google\\Chrome\\Application"
-        PROGRAMFILESX86 = "C:\\Program Files (x86)\\Google\\Chrome\\Application"
+        PROGRAMFILES = f"{os.environ['PROGRAMFILES']}\\Google\\Chrome\\Application"
+        PROGRAMFILESX86 = f"{os.environ['PROGRAMFILES(X86)']}\\Google\\Chrome\\Application"
         
         path = PROGRAMFILES if os.path.exists(PROGRAMFILES) else PROGRAMFILESX86 if os.path.exists(PROGRAMFILESX86) else None
 

--- a/chromedriver_autoinstaller/utils.py
+++ b/chromedriver_autoinstaller/utils.py
@@ -161,18 +161,14 @@ def get_chrome_version():
             .strip()
         )
     elif platform == "win":
-        # check both of Program Files and Program Files (x86).
-        # if the version isn't found on both of them, version is an empty string.
-        PROGRAMFILES = f"{os.environ['PROGRAMFILES']}\\Google\\Chrome\\Application"
-        PROGRAMFILESX86 = f"{os.environ['PROGRAMFILES(X86)']}\\Google\\Chrome\\Application"
+        PROGRAMFILES = f"{os.environ.get('PROGRAMW6432') or os.environ.get('PROGRAMFILES')}\\Google\\Chrome\\Application"
+        PROGRAMFILESX86 = f"{os.environ.get('PROGRAMFILES(X86)')}\\Google\\Chrome\\Application"
         
         path = PROGRAMFILES if os.path.exists(PROGRAMFILES) else PROGRAMFILESX86 if os.path.exists(PROGRAMFILESX86) else None
 
-        if path:
-            dirs = [f.name for f in os.scandir(path) if f.is_dir() and re.match("^[0-9.]+$", f.name)]
-            version = max(dirs)
-        else:
-            version = ''
+        dirs = [f.name for f in os.scandir(path) if f.is_dir() and re.match("^[0-9.]+$", f.name)] if path else None
+
+        version = max(dirs) if dirs else None
     else:
         return
     return version


### PR DESCRIPTION
previous code raises FileNotFoundError, if the path  `Google/Chrome/Application` does not exists in `C:\Program Files`

now, first checks if path exist in `C:\Program Files` if not then checks in `C:\Program Files (x86)` then does the `os.scandir()` to avoid error.

if in both dirs path does not exits then set version to an empty string.